### PR TITLE
[#64] 투표 게시글 작성 중 비정상 이탈 시 게시글 저장 및 불러오기 기능 추가

### DIFF
--- a/App/App/Sources/DI/RepositoryDI.swift
+++ b/App/App/Sources/DI/RepositoryDI.swift
@@ -30,6 +30,10 @@ extension DIContainer {
         container.register(PendingVoteCreateInfoRepository.self) { _ in
             PendingVoteCreateInfoRepositoryImpl()
         }
+        
+        container.register(ReportFeedRepository.self) { _ in
+            ReportFeedRepositoryImpl()
+        }
 
         container.register(UploadsRepository.self) { _ in
             UploadsRepositoryImpl()

--- a/App/App/Sources/DI/RepositoryDI.swift
+++ b/App/App/Sources/DI/RepositoryDI.swift
@@ -26,6 +26,10 @@ extension DIContainer {
         container.register(FeedRepository.self) { _ in
             FeedRepositoryImpl()
         }
+        
+        container.register(PendingVoteCreateInfoRepository.self) { _ in
+            PendingVoteCreateInfoRepositoryImpl()
+        }
 
         container.register(UploadsRepository.self) { _ in
             UploadsRepositoryImpl()

--- a/App/App/Sources/DI/ViewModelDI.swift
+++ b/App/App/Sources/DI/ViewModelDI.swift
@@ -68,9 +68,11 @@ extension DIContainer {
         container.register(HomeViewModel.self) { (resolver: Resolver, argument: HomeViewModel.Argument) in
             let feedRepository: FeedRepository = resolver.resolve()
             let userRepository: UserRepository = resolver.resolve()
+            let reportFeedRepository: ReportFeedRepository = resolver.resolve()
             return HomeViewModel(
                 feedRepository: feedRepository,
                 userRepository: userRepository,
+                reportFeedRepository: reportFeedRepository,
                 argument: argument
             )
         }

--- a/App/App/Sources/DI/ViewModelDI.swift
+++ b/App/App/Sources/DI/ViewModelDI.swift
@@ -78,9 +78,11 @@ extension DIContainer {
         container.register(CreateVoteViewModel.self) { (resolver: Resolver) in
             let uploadsRepository: UploadsRepository = resolver.resolve()
             let feedRepository: FeedRepository = resolver.resolve()
+            let pendingVoteCreateInfoRepository: PendingVoteCreateInfoRepository = resolver.resolve()
             return CreateVoteViewModel(
                 uploadsRepository: uploadsRepository,
-                feedRepository: feedRepository
+                feedRepository: feedRepository,
+                pendingVoteCreateInfoRepository: pendingVoteCreateInfoRepository
             )
         }
 

--- a/App/App/Sources/Navigator/AppAuthNavigator.swift
+++ b/App/App/Sources/Navigator/AppAuthNavigator.swift
@@ -2,7 +2,7 @@
 //  AppNavigator.swift
 //  App
 //
-//  Created by Codex on 2/21/26.
+//  Created by 문종식 on 2/21/26.
 //
 
 import Auth

--- a/App/App/Sources/Navigator/AppVoteNavigator.swift
+++ b/App/App/Sources/Navigator/AppVoteNavigator.swift
@@ -2,7 +2,7 @@
 //  AppNavigator.swift
 //  App
 //
-//  Created by Codex on 2/21/26.
+//  Created by 문종식 on 2/21/26.
 //
 
 import Vote

--- a/App/App/Sources/Navigator/ViewModifier/View+AppNavigationDestination.swift
+++ b/App/App/Sources/Navigator/ViewModifier/View+AppNavigationDestination.swift
@@ -2,7 +2,7 @@
 //  View+AppNavigationDestination.swift
 //  App
 //
-//  Created by Codex on 2/21/26.
+//  Created by 문종식 on 2/21/26.
 //
 
 import SwiftUI

--- a/App/App/Sources/Navigator/ViewModifier/View+AuthNavigationDestination.swift
+++ b/App/App/Sources/Navigator/ViewModifier/View+AuthNavigationDestination.swift
@@ -2,7 +2,7 @@
 //  View+AuthNavigationDestination.swift
 //  App
 //
-//  Created by Codex on 2/21/26.
+//  Created by 문종식 on 2/21/26.
 //
 
 import SwiftUI

--- a/Domain/Domain/Sources/Model/Feed/FeedCategory.swift
+++ b/Domain/Domain/Sources/Model/Feed/FeedCategory.swift
@@ -5,7 +5,7 @@
 //  Created by 문종식 on 2/16/26.
 //
 
-public enum FeedCategory: String {
+public enum FeedCategory: String, CaseIterable {
     case luxury = "LUXURY"
     case fashion = "FASHION"
     case beauty = "BEAUTY"
@@ -39,6 +39,28 @@ public enum FeedCategory: String {
         default:
             self = .etc
         }
-    
+    }
+
+    public var displayName: String {
+        switch self {
+        case .luxury:
+            return "명품∙프리미엄"
+        case .fashion:
+            return "패션 ∙ 잡화"
+        case .beauty:
+            return "화장품∙뷰티"
+        case .food:
+            return "음식"
+        case .electronics:
+            return "전자기기"
+        case .travel:
+            return "여행 쇼핑템"
+        case .health:
+            return "헬스∙운동용품"
+        case .book:
+            return "도서"
+        case .etc:
+            return "기타"
+        }
     }
 }

--- a/Domain/Domain/Sources/Model/Feed/FeedCategory.swift
+++ b/Domain/Domain/Sources/Model/Feed/FeedCategory.swift
@@ -15,31 +15,6 @@ public enum FeedCategory: String, CaseIterable {
     case health = "HEALTH"
     case book = "BOOK"
     case etc = "ETC"
-    
-    public init(rawValue: String) {
-        switch rawValue {
-        case "LUXURY":
-            self = .luxury
-        case "FASHION":
-            self = .fashion
-        case "BEAUTY":
-            self = .beauty
-        case "FOOD":
-            self = .food
-        case "ELECTRONICS":
-            self = .electronics
-        case "TRAVEL":
-            self = .travel
-        case "HEALTH":
-            self = .health
-        case "BOOK":
-            self = .book
-        case "ETC":
-            self = .etc
-        default:
-            self = .etc
-        }
-    }
 
     public var displayName: String {
         switch self {

--- a/Domain/Domain/Sources/Model/Feed/PendingVoteCreateInfo.swift
+++ b/Domain/Domain/Sources/Model/Feed/PendingVoteCreateInfo.swift
@@ -1,0 +1,22 @@
+//
+//  PendingVoteCreateInfo.swift
+//  Domain
+//
+//  Created by Codex on 3/15/26.
+//
+
+public struct PendingVoteCreateInfo: Equatable {
+    public let category: FeedCategory?
+    public let price: String
+    public let content: String
+
+    public init(
+        category: FeedCategory?,
+        price: String,
+        content: String
+    ) {
+        self.category = category
+        self.price = price
+        self.content = content
+    }
+}

--- a/Domain/Domain/Sources/Model/Feed/PendingVoteCreateInfo.swift
+++ b/Domain/Domain/Sources/Model/Feed/PendingVoteCreateInfo.swift
@@ -2,7 +2,7 @@
 //  PendingVoteCreateInfo.swift
 //  Domain
 //
-//  Created by Codex on 3/15/26.
+//  Created by 문종식 on 3/15/26.
 //
 
 public struct PendingVoteCreateInfo: Equatable {

--- a/Domain/Domain/Sources/Model/Feed/ReportFeed.swift
+++ b/Domain/Domain/Sources/Model/Feed/ReportFeed.swift
@@ -1,0 +1,14 @@
+//
+//  ReportFeed.swift
+//  Domain
+//
+//  Created by 문종식 on 3/15/26.
+//
+
+public struct ReportFeed: Equatable {
+    public let ids: Set<String>
+
+    public init(ids: Set<String>) {
+        self.ids = ids
+    }
+}

--- a/Domain/Domain/Sources/Repository/Feed/PendingVoteCreateInfoRepository.swift
+++ b/Domain/Domain/Sources/Repository/Feed/PendingVoteCreateInfoRepository.swift
@@ -2,7 +2,7 @@
 //  PendingVoteCreateInfoRepository.swift
 //  Domain
 //
-//  Created by Codex on 3/15/26.
+//  Created by 문종식 on 3/15/26.
 //
 
 public protocol PendingVoteCreateInfoRepository {

--- a/Domain/Domain/Sources/Repository/Feed/PendingVoteCreateInfoRepository.swift
+++ b/Domain/Domain/Sources/Repository/Feed/PendingVoteCreateInfoRepository.swift
@@ -1,0 +1,12 @@
+//
+//  PendingVoteCreateInfoRepository.swift
+//  Domain
+//
+//  Created by Codex on 3/15/26.
+//
+
+public protocol PendingVoteCreateInfoRepository {
+    func savePendingVoteCreateInfo(_ info: PendingVoteCreateInfo)
+    func getPendingVoteCreateInfo() -> PendingVoteCreateInfo?
+    func removePendingVoteCreateInfo()
+}

--- a/Domain/Domain/Sources/Repository/Feed/ReportFeedRepository.swift
+++ b/Domain/Domain/Sources/Repository/Feed/ReportFeedRepository.swift
@@ -1,0 +1,12 @@
+//
+//  ReportFeedRepository.swift
+//  Domain
+//
+//  Created by 문종식 on 3/15/26.
+//
+
+public protocol ReportFeedRepository {
+    func saveReportFeed(_ feed: ReportFeed)
+    func getReportFeed() -> ReportFeed?
+    func removeReportFeed()
+}

--- a/Feature/Auth/Auth/Sources/Navigator/AuthNavigator.swift
+++ b/Feature/Auth/Auth/Sources/Navigator/AuthNavigator.swift
@@ -2,7 +2,7 @@
 //  AuthNavigator.swift
 //  Auth
 //
-//  Created by Codex on 2/21/26.
+//  Created by 문종식 on 2/21/26.
 //
 
 public protocol AuthNavigator {

--- a/Feature/Auth/Auth/Sources/Utils/SNSAuth/AppleAuth.swift
+++ b/Feature/Auth/Auth/Sources/Utils/SNSAuth/AppleAuth.swift
@@ -2,7 +2,7 @@
 //  AppleAuth.swift
 //  Auth
 //
-//  Created by Codex on 2/13/26.
+//  Created by 문종식 on 2/13/26.
 //
 
 import AuthenticationServices

--- a/Feature/Auth/Auth/Sources/Views/MyPage/DeleteAccountView.swift
+++ b/Feature/Auth/Auth/Sources/Views/MyPage/DeleteAccountView.swift
@@ -32,6 +32,9 @@ public struct DeleteAccountView: View {
                 }
             }
             .padding(20)
+            BNImage(.delete_account)
+                .resizable()
+                .scaledToFit()
             Spacer()
             BNButton(
                 text: "탈퇴하기",

--- a/Feature/Vote/Vote/Sources/Navigator/VoteNavigator.swift
+++ b/Feature/Vote/Vote/Sources/Navigator/VoteNavigator.swift
@@ -2,7 +2,7 @@
 //  VoteNavigator.swift
 //  Vote
 //
-//  Created by Codex on 2/21/26.
+//  Created by 문종식 on 2/21/26.
 //
 
 public protocol VoteNavigator {

--- a/Feature/Vote/Vote/Sources/ViewModels/PostVote/CreateVoteViewModel.swift
+++ b/Feature/Vote/Vote/Sources/ViewModels/PostVote/CreateVoteViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Combine
 import SwiftUI
 import UIKit
 import Photos
@@ -26,12 +27,20 @@ public final class CreateVoteViewModel: ObservableObject {
     @Published var showPhotoPicker = false
     @Published var showCustomAlert = false
     @Published var showCategoryBottomSheet = false
+    @Published var showCancelAlert = false
     
     private let uploadsRepository: UploadsRepository
     private let feedRepository: FeedRepository
+    private let pendingVoteCreateInfoRepository: PendingVoteCreateInfoRepository
+    private var anyCancellable = Set<AnyCancellable>()
+    private var isPendingAutoSaveEnabled = true
     
     var contentsLimitCount: Int {
         _contentsLimitCount
+    }
+
+    var isWritingInProgress: Bool {
+        category != nil || price.isEmpty == false || contents.isEmpty == false
     }
     
     private let _accessLevel: PHAccessLevel = .readWrite
@@ -40,10 +49,13 @@ public final class CreateVoteViewModel: ObservableObject {
 
     public init(
         uploadsRepository: UploadsRepository,
-        feedRepository: FeedRepository
+        feedRepository: FeedRepository,
+        pendingVoteCreateInfoRepository: PendingVoteCreateInfoRepository
     ) {
         self.uploadsRepository = uploadsRepository
         self.feedRepository = feedRepository
+        self.pendingVoteCreateInfoRepository = pendingVoteCreateInfoRepository
+        bindPendingVoteCreateInfoAutoSave()
     }
     
     func didChangeCategory(_ category: FeedCategory) {
@@ -122,6 +134,18 @@ public final class CreateVoteViewModel: ObservableObject {
         selectedImageData = nil
         selectedImage = nil
     }
+
+    func didTapCancel() {
+        if isWritingInProgress {
+            showCancelAlert = true
+        }
+    }
+
+    func removePendingVoteCreateInfo() {
+        isPendingAutoSaveEnabled = false
+        anyCancellable.removeAll()
+        pendingVoteCreateInfoRepository.removePendingVoteCreateInfo()
+    }
     
     private func validatePost() {
         let isValidPrice = price.isEmpty == false
@@ -129,6 +153,24 @@ public final class CreateVoteViewModel: ObservableObject {
         let isValidImage = selectedImageData != nil && selectedImage != nil
         let isValid = isValidImage && isValidCategory && isValidPrice
         createButtonState = isValid ? .enabled : .disabled
+    }
+
+    private func bindPendingVoteCreateInfoAutoSave() {
+        Publishers.CombineLatest3($category, $price, $contents)
+            .dropFirst()
+            .debounce(for: .milliseconds(500), scheduler: RunLoop.main)
+            .sink { [weak self] category, price, contents in
+                guard let self, self.isPendingAutoSaveEnabled else {
+                    return
+                }
+                let info = PendingVoteCreateInfo(
+                    category: category,
+                    price: price,
+                    content: contents
+                )
+                self.pendingVoteCreateInfoRepository.savePendingVoteCreateInfo(info)
+            }
+            .store(in: &anyCancellable)
     }
     
     @MainActor

--- a/Feature/Vote/Vote/Sources/ViewModels/PostVote/CreateVoteViewModel.swift
+++ b/Feature/Vote/Vote/Sources/ViewModels/PostVote/CreateVoteViewModel.swift
@@ -15,25 +15,10 @@ import Core
 import Domain
 
 public final class CreateVoteViewModel: ObservableObject {
-    // TODO: - 26.02.06. 더미 데이터 사용 중 Model 정의 필요
-    // ================================
     @Published var contents: String = ""
     @Published var price: String = ""
-    @Published var category: String? = nil
-    @Published var categories: [String] = [
-        "명품∙프리미엄",
-        "패션 ∙ 잡화",
-        "화장품∙뷰티",
-        "트렌드∙가성비템",
-        "음식",
-        "전자기기",
-        "여행 쇼핑템",
-        "헬스∙운동용품",
-        "도서",
-        "기타",
-    ]
-    // ================================
-    
+    @Published var category: FeedCategory? = nil
+    @Published var categories: [FeedCategory] = FeedCategory.allCases
     
     @Published var createButtonState: BNButtonState = .disabled
     @Published var selectedImageData: Data?
@@ -61,7 +46,7 @@ public final class CreateVoteViewModel: ObservableObject {
         self.feedRepository = feedRepository
     }
     
-    func didChangeCategory(_ category: String) {
+    func didChangeCategory(_ category: FeedCategory) {
         defer {
             validatePost()
         }
@@ -150,8 +135,7 @@ public final class CreateVoteViewModel: ObservableObject {
     func postVote() async -> Bool {
         guard
             let data = selectedImageData,
-            let categoryText = category,
-            let feedCategory = mapCategory(categoryText),
+            let selectedCategory = category,
             let priceValue = price.toInt
         else {
             return false
@@ -170,7 +154,7 @@ public final class CreateVoteViewModel: ObservableObject {
             )
 
             let info = VoteCreateInfo(
-                category: feedCategory,
+                category: selectedCategory,
                 price: priceValue,
                 content: contents,
                 s3ObjectKey: imageInfo.s3ObjectKey,
@@ -184,20 +168,6 @@ public final class CreateVoteViewModel: ObservableObject {
             print("[CreateVoteViewModel] postVote error: \(error)")
             return false
         }
-    }
-
-    private func mapCategory(_ text: String) -> FeedCategory? {
-        if text.contains("명품") { return .luxury }
-        if text.contains("패션") { return .fashion }
-        if text.contains("화장품") || text.contains("뷰티") { return .beauty }
-        if text.contains("음식") { return .food }
-        if text.contains("전자기기") { return .electronics }
-        if text.contains("여행") { return .travel }
-        if text.contains("헬스") || text.contains("운동") { return .health }
-        if text.contains("도서") { return .book }
-        if text.contains("기타") { return .etc }
-        if text.contains("트렌드") || text.contains("가성비") { return .etc }
-        return nil
     }
 
     private func detectContentType(_ data: Data) -> String? {

--- a/Feature/Vote/Vote/Sources/ViewModels/PostVote/CreateVoteViewModel.swift
+++ b/Feature/Vote/Vote/Sources/ViewModels/PostVote/CreateVoteViewModel.swift
@@ -28,12 +28,14 @@ public final class CreateVoteViewModel: ObservableObject {
     @Published var showCustomAlert = false
     @Published var showCategoryBottomSheet = false
     @Published var showCancelAlert = false
+    @Published var showRestorePendingAlert = false
     
     private let uploadsRepository: UploadsRepository
     private let feedRepository: FeedRepository
     private let pendingVoteCreateInfoRepository: PendingVoteCreateInfoRepository
     private var anyCancellable = Set<AnyCancellable>()
     private var isPendingAutoSaveEnabled = true
+    private var pendingVoteCreateInfoToRestore: PendingVoteCreateInfo?
     
     var contentsLimitCount: Int {
         _contentsLimitCount
@@ -139,6 +141,33 @@ public final class CreateVoteViewModel: ObservableObject {
         if isWritingInProgress {
             showCancelAlert = true
         }
+    }
+
+    @discardableResult
+    func checkPendingVoteCreateInfoOnAppear() -> Bool {
+        guard pendingVoteCreateInfoToRestore == nil else {
+            return false
+        }
+        guard let info = pendingVoteCreateInfoRepository.getPendingVoteCreateInfo() else {
+            return false
+        }
+        guard info.category != nil || info.price.isEmpty == false || info.content.isEmpty == false else {
+            return false
+        }
+        pendingVoteCreateInfoToRestore = info
+        showRestorePendingAlert = true
+        return true
+    }
+
+    func restorePendingVoteCreateInfo() {
+        guard let info = pendingVoteCreateInfoToRestore else {
+            return
+        }
+        category = info.category
+        price = info.price
+        contents = info.content
+        validatePost()
+        showRestorePendingAlert = false
     }
 
     func removePendingVoteCreateInfo() {

--- a/Feature/Vote/Vote/Sources/ViewModels/VoteFeed/HomeViewModel.swift
+++ b/Feature/Vote/Vote/Sources/ViewModels/VoteFeed/HomeViewModel.swift
@@ -12,6 +12,7 @@ import DesignSystem
 public final class HomeViewModel: ObservableObject {
     private let feedRepository: FeedRepository
     private let userRepository: UserRepository
+    private let reportFeedRepository: ReportFeedRepository
     private let navigator: VoteNavigator
     private let currentUserId: Int?
     private let pageSize = 10
@@ -26,12 +27,22 @@ public final class HomeViewModel: ObservableObject {
 
     private var cursor: Int?
     private var hasMorePages: Bool = true
+    private var removedFeedIds: Set<String> = []
+    private var reportedFeedIds: Set<String> = []
 
-    public init(feedRepository: FeedRepository, userRepository: UserRepository, argument: HomeViewModel.Argument) {
+    public init(
+        feedRepository: FeedRepository,
+        userRepository: UserRepository,
+        reportFeedRepository: ReportFeedRepository,
+        argument: HomeViewModel.Argument
+    ) {
         self.feedRepository = feedRepository
         self.userRepository = userRepository
+        self.reportFeedRepository = reportFeedRepository
         self.navigator = argument.navigator
         self.currentUserId = userRepository.getCachedUser()?.id
+        self.reportedFeedIds = reportFeedRepository.getReportFeed()?.ids ?? []
+        self.removedFeedIds = reportedFeedIds
         #if DEBUG
         print("🔍 [HomeViewModel] currentUserId: \(String(describing: self.currentUserId))")
         #endif
@@ -60,7 +71,9 @@ public final class HomeViewModel: ObservableObject {
                 size: pageSize,
                 feedStatus: feedStatusParam(for: selectedFilter)
             )
-            feeds = page.votes.map { toVoteFeedData($0) }
+            feeds = page.votes
+                .filter { removedFeedIds.contains(String($0.feedId)) == false }
+                .map { toVoteFeedData($0) }
             cursor = page.nextCursor
             hasMorePages = page.hasNext
             voteFeedState = .success
@@ -84,7 +97,11 @@ public final class HomeViewModel: ObservableObject {
                 size: pageSize,
                 feedStatus: feedStatusParam(for: selectedFilter)
             )
-            feeds.append(contentsOf: page.votes.map { toVoteFeedData($0) })
+            appendUniqueFeeds(
+                page.votes
+                    .filter { removedFeedIds.contains(String($0.feedId)) == false }
+                    .map { toVoteFeedData($0) }
+            )
             cursor = page.nextCursor
             hasMorePages = page.hasNext
         } catch {
@@ -104,11 +121,13 @@ public final class HomeViewModel: ObservableObject {
         guard let id = Int(feedId) else { return }
         do {
             try await feedRepository.deleteVoteFeed(feedId: id)
+            removedFeedIds.insert(feedId)
             feeds.removeAll { $0.id == feedId }
             myFeeds.removeAll { $0.id == feedId }
             if myFeeds.isEmpty {
                 myVoteState = .empty
             }
+            await backfillFeedIfNeeded()
         } catch {
             print("[HomeViewModel] deleteFeed error: \(error)")
         }
@@ -119,7 +138,17 @@ public final class HomeViewModel: ObservableObject {
         guard let id = Int(feedId) else { return }
         do {
             try await feedRepository.reportVoteFeed(feedId: id)
+            removedFeedIds.insert(feedId)
+            reportedFeedIds.insert(feedId)
+            reportFeedRepository.saveReportFeed(
+                ReportFeed(ids: reportedFeedIds)
+            )
             feeds.removeAll { $0.id == feedId }
+            myFeeds.removeAll { $0.id == feedId }
+            if myFeeds.isEmpty {
+                myVoteState = .empty
+            }
+            await backfillFeedIfNeeded()
         } catch {
             print("[HomeViewModel] reportFeed error: \(error)")
         }
@@ -146,16 +175,60 @@ public final class HomeViewModel: ObservableObject {
                 size: pageSize,
                 feedStatus: feedStatusParam(for: selectedFilter)
             )
-            if page.votes.isEmpty {
+            let filteredVotes = page.votes.filter {
+                removedFeedIds.contains(String($0.feedId)) == false
+            }
+            if filteredVotes.isEmpty {
                 myFeeds = []
                 myVoteState = .empty
             } else {
-                myFeeds = page.votes.map { toVoteFeedData($0, isMine: true) }
+                myFeeds = filteredVotes.map { toVoteFeedData($0, isMine: true) }
                 myVoteState = .success
             }
         } catch {
             print("[HomeViewModel] fetchMyFeeds error: \(error)")
             myVoteState = .error
+        }
+    }
+
+    @MainActor
+    private func backfillFeedIfNeeded() async {
+        guard hasMorePages, isLoadingMore == false else {
+            return
+        }
+        isLoadingMore = true
+        defer { isLoadingMore = false }
+
+        while hasMorePages {
+            do {
+                let page = try await feedRepository.getVoteFeeds(
+                    cursor: cursor,
+                    size: pageSize,
+                    feedStatus: feedStatusParam(for: selectedFilter)
+                )
+                cursor = page.nextCursor
+                hasMorePages = page.hasNext
+
+                let newFeeds = page.votes
+                    .filter { removedFeedIds.contains(String($0.feedId)) == false }
+                    .map { toVoteFeedData($0) }
+                appendUniqueFeeds(newFeeds)
+
+                if newFeeds.isEmpty == false {
+                    break
+                }
+            } catch {
+                break
+            }
+        }
+    }
+
+    private func appendUniqueFeeds(_ items: [VoteFeedData]) {
+        guard items.isEmpty == false else { return }
+        var existingFeedIds = Set(feeds.map(\.id))
+        for item in items where existingFeedIds.contains(item.id) == false {
+            feeds.append(item)
+            existingFeedIds.insert(item.id)
         }
     }
 

--- a/Feature/Vote/Vote/Sources/Views/PostVote/CategorySheetView.swift
+++ b/Feature/Vote/Vote/Sources/Views/PostVote/CategorySheetView.swift
@@ -7,16 +7,17 @@
 
 import SwiftUI
 import DesignSystem
+import Domain
 
 struct CategorySheetView: View {
-    let category: [String]
-    let selectedCategory: String?
-    let didTapCategory: (String) -> Void
+    let category: [FeedCategory]
+    let selectedCategory: FeedCategory?
+    let didTapCategory: (FeedCategory) -> Void
     
     init(
-        _ category: [String],
-        _ selectedCategory: String?,
-        _ didTapCategory: @escaping (String) -> Void
+        _ category: [FeedCategory],
+        _ selectedCategory: FeedCategory?,
+        _ didTapCategory: @escaping (FeedCategory) -> Void
     ) {
         self.category = category
         self.selectedCategory = selectedCategory
@@ -36,7 +37,7 @@ struct CategorySheetView: View {
                                 didTapCategory(item)
                             } label: {
                                 HStack {
-                                    BNText(item)
+                                    BNText(item.displayName)
                                         .style(
                                             style: item == selectedCategory ? .s3sb : .b3m,
                                             color: item == selectedCategory ? .gray900 : .gray700
@@ -78,20 +79,9 @@ struct CategorySheetView: View {
 
 
 #Preview {
-    let category = [
-        "명품∙프리미엄",
-        "패션 ∙ 잡화",
-        "화장품∙뷰티",
-        "트렌드∙가성비템",
-        "음식",
-        "전자기기",
-        "여행 쇼핑템",
-        "헬스∙운동용품",
-        "도서",
-        "기타",
-    ]
+    let category = FeedCategory.allCases
     CategorySheetView(
         category,
-        "여행 쇼핑템"
+        .travel
     ) { _ in }
 }

--- a/Feature/Vote/Vote/Sources/Views/PostVote/CreateVoteView.swift
+++ b/Feature/Vote/Vote/Sources/Views/PostVote/CreateVoteView.swift
@@ -57,7 +57,13 @@ public struct CreateVoteView: View {
             .padding(.horizontal, 20)
         }
         .onAppear {
-            self.focusState = .price
+            let shouldShowRestoreAlert = viewModel.checkPendingVoteCreateInfoOnAppear()
+            self.focusState = shouldShowRestoreAlert ? nil : .price
+        }
+        .onChange(of: viewModel.showRestorePendingAlert) { _, isPresented in
+            if isPresented {
+                focusState = nil
+            }
         }
         .interactiveDismissDisabled(true)
         .padding(.top, 20)
@@ -116,6 +122,26 @@ public struct CreateVoteView: View {
                         text: "유지하기",
                         type: .primary
                     ) { }
+                ]
+            )
+        )
+        .bnAlert(
+            isPresented: $viewModel.showRestorePendingAlert,
+            isEnableDismiss: true,
+            config: BNAlertConfig(
+                title: "이전에 작성하던 글이 있어요!",
+                message: "[닫기] 선택 시 해당 내용은 복구할 수 없어요.",
+                buttons: [
+                    .close,
+                    BNAlertButtonConfig(
+                        text: "불러오기",
+                        type: .primary
+                    ) {
+                        viewModel.restorePendingVoteCreateInfo()
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                            focusState = .price
+                        }
+                    }
                 ]
             )
         )

--- a/Feature/Vote/Vote/Sources/Views/PostVote/CreateVoteView.swift
+++ b/Feature/Vote/Vote/Sources/Views/PostVote/CreateVoteView.swift
@@ -110,7 +110,7 @@ public struct CreateVoteView: View {
     }
     
     @ViewBuilder
-    private func category(_ text: String?) -> some View {
+    private func category(_ selectedCategory: FeedCategory?) -> some View {
         HStack(spacing: 8) {
             BNText("투표 등록")
                 .style(style: .s3sb, color: .gray800)
@@ -119,8 +119,8 @@ public struct CreateVoteView: View {
             Button {
                 viewModel.showCategoryBottomSheet = true
             } label: {
-                if let text {
-                    BNText(text)
+                if let selectedCategory {
+                    BNText(selectedCategory.displayName)
                         .style(style: .s3sb, color: .gray800)
                 } else {
                     BNText("카테고리 추가")

--- a/Feature/Vote/Vote/Sources/Views/PostVote/CreateVoteView.swift
+++ b/Feature/Vote/Vote/Sources/Views/PostVote/CreateVoteView.swift
@@ -59,6 +59,7 @@ public struct CreateVoteView: View {
         .onAppear {
             self.focusState = .price
         }
+        .interactiveDismissDisabled(true)
         .padding(.top, 20)
         .padding(.bottom, 10)
         .sheet(isPresented: $viewModel.showPhotoPicker) {

--- a/Feature/Vote/Vote/Sources/Views/PostVote/CreateVoteView.swift
+++ b/Feature/Vote/Vote/Sources/Views/PostVote/CreateVoteView.swift
@@ -98,12 +98,37 @@ public struct CreateVoteView: View {
                 ]
             )
         )
+        .bnAlert(
+            isPresented: $viewModel.showCancelAlert,
+            isEnableDismiss: true,
+            config: BNAlertConfig(
+                title: "다음에 등록할까요?",
+                message: "지금까지 쓴 내용은 저장되지 않아요.",
+                buttons: [
+                    BNAlertButtonConfig(
+                        text: "나가기",
+                        type: .secondaryLarge
+                    ) {
+                        viewModel.removePendingVoteCreateInfo()
+                        dismiss()
+                    },
+                    BNAlertButtonConfig(
+                        text: "유지하기",
+                        type: .primary
+                    ) { }
+                ]
+            )
+        )
     }
     
     @ViewBuilder
     private var cancel: some View {
         Button {
-            dismiss()
+            if viewModel.isWritingInProgress {
+                viewModel.didTapCancel()
+            } else {
+                dismiss()
+            }
         } label: {
             BNText("취소")
                 .style(style: .s4sb, color: .gray700)
@@ -298,11 +323,18 @@ private struct MockFeedRepository: FeedRepository {
     }
 }
 
+private struct MockPendingVoteCreateInfoRepository: PendingVoteCreateInfoRepository {
+    func savePendingVoteCreateInfo(_ info: PendingVoteCreateInfo) {}
+    func getPendingVoteCreateInfo() -> PendingVoteCreateInfo? { nil }
+    func removePendingVoteCreateInfo() {}
+}
+
 #Preview {
     CreateVoteView(
         viewModel: CreateVoteViewModel(
             uploadsRepository: MockUploadsRepository(),
-            feedRepository: MockFeedRepository()
+            feedRepository: MockFeedRepository(),
+            pendingVoteCreateInfoRepository: MockPendingVoteCreateInfoRepository()
         )
     )
 }

--- a/Feature/Vote/Vote/Sources/Views/VoteFeed/HomeView.swift
+++ b/Feature/Vote/Vote/Sources/Views/VoteFeed/HomeView.swift
@@ -322,6 +322,12 @@ private struct PreviewUserRepository: UserRepository {
     func deleteAccount() async throws {}
 }
 
+private struct PreviewReportFeedRepository: ReportFeedRepository {
+    func saveReportFeed(_ feed: ReportFeed) {}
+    func getReportFeed() -> ReportFeed? { nil }
+    func removeReportFeed() {}
+}
+
 private struct MockVoteNavigator: VoteNavigator {
     func navigateToNotification() {}
     func navigateToMyPage() {}
@@ -335,6 +341,7 @@ private struct MockVoteNavigator: VoteNavigator {
         viewModel: HomeViewModel(
             feedRepository: PreviewFeedRepository(),
             userRepository: PreviewUserRepository(),
+            reportFeedRepository: PreviewReportFeedRepository(),
             argument: .init(
                 navigator: MockVoteNavigator()
             )

--- a/Service/Service/Sources/Local/DTO/PendingVoteCreateInfoEntity.swift
+++ b/Service/Service/Sources/Local/DTO/PendingVoteCreateInfoEntity.swift
@@ -2,7 +2,7 @@
 //  PendingVoteCreateInfoEntity.swift
 //  Service
 //
-//  Created by Codex on 3/15/26.
+//  Created by 문종식 on 3/15/26.
 //
 
 struct PendingVoteCreateInfoEntity: Codable {

--- a/Service/Service/Sources/Local/DTO/PendingVoteCreateInfoEntity.swift
+++ b/Service/Service/Sources/Local/DTO/PendingVoteCreateInfoEntity.swift
@@ -1,0 +1,18 @@
+//
+//  PendingVoteCreateInfoEntity.swift
+//  Service
+//
+//  Created by Codex on 3/15/26.
+//
+
+struct PendingVoteCreateInfoEntity: Codable {
+    let category: String?
+    let price: String
+    let content: String
+
+    init(category: String?, price: String, content: String) {
+        self.category = category
+        self.price = price
+        self.content = content
+    }
+}

--- a/Service/Service/Sources/Local/DTO/ReportFeedEntity.swift
+++ b/Service/Service/Sources/Local/DTO/ReportFeedEntity.swift
@@ -1,0 +1,14 @@
+//
+//  ReportFeedEntity.swift
+//  Service
+//
+//  Created by 문종식 on 3/15/26.
+//
+
+struct ReportFeedEntity: Codable {
+    let ids: Set<String>
+
+    init(ids: Set<String>) {
+        self.ids = ids
+    }
+}

--- a/Service/Service/Sources/Local/Store/PendingVoteCreateInfoStore.swift
+++ b/Service/Service/Sources/Local/Store/PendingVoteCreateInfoStore.swift
@@ -1,0 +1,35 @@
+//
+//  PendingVoteCreateInfoStore.swift
+//  Service
+//
+//  Created by Codex on 3/15/26.
+//
+
+import Domain
+
+final class PendingVoteCreateInfoStore: EntityStore {
+    let client: UserDefaultsClientProtocol
+    let key: UserDefaultsKey = .pendingVoteCreateInfo
+
+    init() {
+        self.client = UserDefaultsClient()
+    }
+
+    func savePendingVoteCreateInfo(_ info: PendingVoteCreateInfo) {
+        let entity = PendingVoteCreateInfoEntity(
+            category: info.category?.rawValue,
+            price: info.price,
+            content: info.content
+        )
+        client.set(entity, for: key)
+    }
+
+    func getPendingVoteCreateInfo() -> PendingVoteCreateInfo? {
+        let entity: PendingVoteCreateInfoEntity? = client.get(for: key)
+        return entity?.toDomain()
+    }
+
+    func removePendingVoteCreateInfo() {
+        client.remove(for: key)
+    }
+}

--- a/Service/Service/Sources/Local/Store/PendingVoteCreateInfoStore.swift
+++ b/Service/Service/Sources/Local/Store/PendingVoteCreateInfoStore.swift
@@ -2,7 +2,7 @@
 //  PendingVoteCreateInfoStore.swift
 //  Service
 //
-//  Created by Codex on 3/15/26.
+//  Created by 문종식 on 3/15/26.
 //
 
 import Domain

--- a/Service/Service/Sources/Local/Store/ReportFeedStore.swift
+++ b/Service/Service/Sources/Local/Store/ReportFeedStore.swift
@@ -1,0 +1,31 @@
+//
+//  ReportFeedStore.swift
+//  Service
+//
+//  Created by 문종식 on 3/15/26.
+//
+
+import Domain
+
+final class ReportFeedStore: EntityStore {
+    let client: UserDefaultsClientProtocol
+    let key: UserDefaultsKey = .reportFeed
+
+    init() {
+        self.client = UserDefaultsClient()
+    }
+
+    func saveReportFeed(_ feed: ReportFeed) {
+        let entity = ReportFeedEntity(ids: feed.ids)
+        client.set(entity, for: key)
+    }
+
+    func getReportFeed() -> ReportFeed? {
+        let entity: ReportFeedEntity? = client.get(for: key)
+        return entity?.toDomain()
+    }
+
+    func removeReportFeed() {
+        client.remove(for: key)
+    }
+}

--- a/Service/Service/Sources/Local/UserDefaultsKey.swift
+++ b/Service/Service/Sources/Local/UserDefaultsKey.swift
@@ -8,4 +8,5 @@
 public enum UserDefaultsKey: String, CaseIterable {
     case token = "TOKEN"
     case user = "USER"
+    case pendingVoteCreateInfo = "PENDING_VOTE_CREATE_INFO"
 }

--- a/Service/Service/Sources/Local/UserDefaultsKey.swift
+++ b/Service/Service/Sources/Local/UserDefaultsKey.swift
@@ -9,4 +9,5 @@ public enum UserDefaultsKey: String, CaseIterable {
     case token = "TOKEN"
     case user = "USER"
     case pendingVoteCreateInfo = "PENDING_VOTE_CREATE_INFO"
+    case reportFeed = "REPORT_FEED"
 }

--- a/Service/Service/Sources/Mapper/Local/PendingVoteCreateInfoEntity+Extension.swift
+++ b/Service/Service/Sources/Mapper/Local/PendingVoteCreateInfoEntity+Extension.swift
@@ -2,7 +2,7 @@
 //  PendingVoteCreateInfoEntity+Extension.swift
 //  Service
 //
-//  Created by Codex on 3/15/26.
+//  Created by 문종식 on 3/15/26.
 //
 
 import Domain

--- a/Service/Service/Sources/Mapper/Local/PendingVoteCreateInfoEntity+Extension.swift
+++ b/Service/Service/Sources/Mapper/Local/PendingVoteCreateInfoEntity+Extension.swift
@@ -1,0 +1,18 @@
+//
+//  PendingVoteCreateInfoEntity+Extension.swift
+//  Service
+//
+//  Created by Codex on 3/15/26.
+//
+
+import Domain
+
+extension PendingVoteCreateInfoEntity {
+    func toDomain() -> PendingVoteCreateInfo {
+        PendingVoteCreateInfo(
+            category: category.flatMap(FeedCategory.init(rawValue:)),
+            price: price,
+            content: content
+        )
+    }
+}

--- a/Service/Service/Sources/Mapper/Local/ReportFeedEntity+Extension.swift
+++ b/Service/Service/Sources/Mapper/Local/ReportFeedEntity+Extension.swift
@@ -1,0 +1,14 @@
+//
+//  ReportFeedEntity+Extension.swift
+//  Service
+//
+//  Created by 문종식 on 3/15/26.
+//
+
+import Domain
+
+extension ReportFeedEntity {
+    func toDomain() -> ReportFeed {
+        ReportFeed(ids: ids)
+    }
+}

--- a/Service/Service/Sources/Mapper/Network/FeedsResponse+Extension.swift
+++ b/Service/Service/Sources/Mapper/Network/FeedsResponse+Extension.swift
@@ -16,7 +16,7 @@ extension FeedsResponse {
             price: self.price,
             category: FeedCategory(
                 rawValue: self.category
-            ),
+            ) ?? .etc,
             yesCount: self.yesCount,
             noCount: self.noCount,
             voteStatus: VoteStatus(

--- a/Service/Service/Sources/Network/PresignedUploadClient.swift
+++ b/Service/Service/Sources/Network/PresignedUploadClient.swift
@@ -2,7 +2,7 @@
 //  PresignedUploadClient.swift
 //  Service
 //
-//  Created by Codex on 2/16/26.
+//  Created by 문종식 on 2/16/26.
 //
 
 import Foundation

--- a/Service/Service/Sources/RepositoryImpls/PendingVoteCreateInfoRepositoryImpl.swift
+++ b/Service/Service/Sources/RepositoryImpls/PendingVoteCreateInfoRepositoryImpl.swift
@@ -2,7 +2,7 @@
 //  PendingVoteCreateInfoRepositoryImpl.swift
 //  Service
 //
-//  Created by Codex on 3/15/26.
+//  Created by 문종식 on 3/15/26.
 //
 
 import Domain

--- a/Service/Service/Sources/RepositoryImpls/PendingVoteCreateInfoRepositoryImpl.swift
+++ b/Service/Service/Sources/RepositoryImpls/PendingVoteCreateInfoRepositoryImpl.swift
@@ -1,0 +1,28 @@
+//
+//  PendingVoteCreateInfoRepositoryImpl.swift
+//  Service
+//
+//  Created by Codex on 3/15/26.
+//
+
+import Domain
+
+public final class PendingVoteCreateInfoRepositoryImpl: PendingVoteCreateInfoRepository {
+    private let store: PendingVoteCreateInfoStore
+
+    public init() {
+        self.store = PendingVoteCreateInfoStore()
+    }
+
+    public func savePendingVoteCreateInfo(_ info: PendingVoteCreateInfo) {
+        store.savePendingVoteCreateInfo(info)
+    }
+
+    public func getPendingVoteCreateInfo() -> PendingVoteCreateInfo? {
+        store.getPendingVoteCreateInfo()
+    }
+
+    public func removePendingVoteCreateInfo() {
+        store.removePendingVoteCreateInfo()
+    }
+}

--- a/Service/Service/Sources/RepositoryImpls/ReportFeedRepositoryImpl.swift
+++ b/Service/Service/Sources/RepositoryImpls/ReportFeedRepositoryImpl.swift
@@ -1,0 +1,28 @@
+//
+//  ReportFeedRepositoryImpl.swift
+//  Service
+//
+//  Created by 문종식 on 3/15/26.
+//
+
+import Domain
+
+public final class ReportFeedRepositoryImpl: ReportFeedRepository {
+    private let store: ReportFeedStore
+
+    public init() {
+        self.store = ReportFeedStore()
+    }
+
+    public func saveReportFeed(_ feed: ReportFeed) {
+        store.saveReportFeed(feed)
+    }
+
+    public func getReportFeed() -> ReportFeed? {
+        store.getReportFeed()
+    }
+
+    public func removeReportFeed() {
+        store.removeReportFeed()
+    }
+}


### PR DESCRIPTION
<!-- pull_request_template.md -->

## 📌 Summary
<!-- PR 요약을 써주세요. -->

- 작성 중인 피드 저장 기능 추가
- 신고 시 게시글 미표시 추가
- 회원 탈퇴 이미지 추가

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->

- issue #65
- closes #64

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->

## 📚 Reference
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->

## 🔥 Test
<!-- Test -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 투표 작성 중 데이터가 자동으로 저장되며, 나중에 복구할 수 있습니다.
  * 피드를 신고할 수 있는 기능이 추가되었습니다.
  * 카테고리가 이제 더 명확한 이름으로 표시됩니다.

* **개선 사항**
  * 신고하거나 삭제한 피드가 피드 목록에서 필터링됩니다.
  * 투표 작성 중 나가기 시 확인 알림이 표시됩니다.
  * 계정 삭제 페이지의 UI가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->