### PR TITLE
[#83] fix: 마이페이지 헤더 및 피드 UI 개선

### DIFF
--- a/Feature/Auth/Auth/Sources/Views/MyPage/MyPageView.swift
+++ b/Feature/Auth/Auth/Sources/Views/MyPage/MyPageView.swift
@@ -86,8 +86,21 @@ public struct MyPageView: View {
                 )
                 .frame(width: 42, height: 42)
         } else {
-            KFImage.url(URL(string: viewModel.profileImageURL))
-                .placeholder {
+            AsyncImage(url: URL(string: viewModel.profileImageURL)) { phase in
+                switch phase {
+                case .success(let image):
+                    image
+                        .resizable()
+                        .scaledToFill()
+                case .empty:
+                    Circle()
+                        .fill(ColorPalette.gray100)
+                        .overlay(
+                            Circle()
+                                .stroke(ColorPalette.gray300, lineWidth: 1.3)
+                        )
+                        .overlay(ProgressView())
+                default:
                     Circle()
                         .fill(ColorPalette.gray100)
                         .overlay(
@@ -95,8 +108,7 @@ public struct MyPageView: View {
                                 .stroke(ColorPalette.gray300, lineWidth: 1.3)
                         )
                 }
-                .resizable()
-                .scaledToFill()
+            }
             .frame(width: 42, height: 42)
             .clipShape(Circle())
         }

--- a/Feature/Auth/Auth/Sources/Views/MyPage/PolicyView.swift
+++ b/Feature/Auth/Auth/Sources/Views/MyPage/PolicyView.swift
@@ -27,6 +27,7 @@ public struct PolicyView: View {
                 .basedOnSize,
                 axes: .vertical
             )
+            .padding(.top, 10)
         }
         .navigationBarHidden(true)
         .sheet(

--- a/Feature/Vote/Vote/Sources/Views/Components/VoteButton.swift
+++ b/Feature/Vote/Vote/Sources/Views/Components/VoteButton.swift
@@ -59,7 +59,7 @@ public struct VoteButton: View {
                 let targetWidth = geometry.size.width * CGFloat(percent) / 100
 
                 ZStack(alignment: .leading) {
-                    buttonContent(textColor: VoteButtonStyle.plain.textColor)
+                    buttonContent(textColor: showPercent && style == .gray ? style.textColor : VoteButtonStyle.plain.textColor)
                             .background(VoteButtonStyle.plain.backgroundColor)
 
                     if showPercent {

--- a/Feature/Vote/Vote/Sources/Views/Components/VoteFeed.swift
+++ b/Feature/Vote/Vote/Sources/Views/Components/VoteFeed.swift
@@ -316,6 +316,7 @@ private struct ProductImageCard: View {
                 
                 BNText(price)
                     .style(style: .t1b, color: ColorPalette.gray0)
+                    .shadow(color: Color.black.opacity(0.3), radius: 4, x: 0, y: 4)
                     .padding(.leading, 14)
                     .padding(.bottom, 16)
                 

--- a/Feature/Vote/Vote/Sources/Views/VoteFeed/HomeView.swift
+++ b/Feature/Vote/Vote/Sources/Views/VoteFeed/HomeView.swift
@@ -81,6 +81,7 @@ public struct HomeView: View {
                     item: viewModel.snackBar.currentItem,
                     state: $viewModel.snackBar.barState
                 )
+                .padding(.bottom, 90)
             }
         }
         .task {

--- a/Service/Service/Sources/RepositoryImpls/UserRepositoryImpl.swift
+++ b/Service/Service/Sources/RepositoryImpls/UserRepositoryImpl.swift
@@ -33,9 +33,6 @@ public class UserRepositoryImpl: UserRepository {
     }
 
     public func getMe() async throws -> User {
-        if let user = userStore.getUser() {
-            return user
-        }
         let response: BaseResponse<UserResponse> = try await request(.getMe)
         let data = response.data.toDomain()
         userStore.saveUser(data)


### PR DESCRIPTION
<!-- pull_request_template.md -->

## 📌 Summary
<!-- PR 요약을 써주세요. -->
마이페이지 헤더 영역 개선 및 피드 관련 UI 버그를 수정합니다.

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 마이페이지 프로필 이미지 로딩 상태 처리 개선 (phase 분기 처리)
- 약관 페이지 헤더 상단 간격 조정
- 피드 가격 텍스트에 그림자 추가
- 투표 완료 후 비선택 버튼(gray) 텍스트 색상 통일
- 차단 후 스낵바 위치를 플로팅 버튼 10pt 위로 조정

- close: #83 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->

## 📚 Reference
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->

## 🔥 Test
<!-- Test -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 프로필 이미지 로딩 시 진행 표시(로딩 인디케이터) 추가

* **UI/디자인 개선**
  * 상품 가격 텍스트에 그림자 추가로 가독성 향상
  * 스크롤 뷰 및 스낵바 하단 여백 조정으로 레이아웃 개선
  * 투표 버튼의 텍스트 색상 조건 표현 개선

* **개선 사항**
  * 사용자 정보 조회 로직 변경으로 데이터 동기화 신뢰성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->