### PR TITLE
[#107] 바텀시트 디자인 시스템 세분화

### DIFF
--- a/App/Derived/InfoPlists/App-Info.plist
+++ b/App/Derived/InfoPlists/App-Info.plist
@@ -23,7 +23,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.6</string>
+	<string>0.0.7</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/App/Project.swift
+++ b/App/Project.swift
@@ -8,7 +8,7 @@
 import ProjectDescription
 import ProjectDescriptionHelpers
 
-let version = "0.0.7"
+let version = "0.0.8"
 let build = 0
 
 let project = Module.app.project(

--- a/App/Project.swift
+++ b/App/Project.swift
@@ -8,7 +8,7 @@
 import ProjectDescription
 import ProjectDescriptionHelpers
 
-let version = "0.0.6"
+let version = "0.0.7"
 let build = 0
 
 let project = Module.app.project(

--- a/DesignSystem/DesignSystem/Sources/Component/BottomSheet/ActionBottomSheet.swift
+++ b/DesignSystem/DesignSystem/Sources/Component/BottomSheet/ActionBottomSheet.swift
@@ -1,0 +1,49 @@
+//
+//  ActionBottomSheet.swift
+//  DesignSystem
+//
+//  Created by Codex on 4/28/26.
+//
+
+import SwiftUI
+
+public struct ActionBottomSheetModifier<SheetView: View>: ViewModifier {
+    @Binding private var isPresented: Bool
+    private let isEnableDismiss: Bool
+    private let child: (@escaping VoidCallBack) -> SheetView
+
+    public init(
+        isPresented: Binding<Bool>,
+        isEnableDismiss: Bool = true,
+        @ViewBuilder child: @escaping (@escaping VoidCallBack) -> SheetView
+    ) {
+        self._isPresented = isPresented
+        self.isEnableDismiss = isEnableDismiss
+        self.child = child
+    }
+
+    public func body(content: Content) -> some View {
+        content
+            .bnBottomSheet(
+                isPresented: $isPresented,
+                isEnableDismiss: isEnableDismiss,
+                child: child
+            )
+    }
+}
+
+public extension View {
+    func actionBottomSheet<SheetContent: View>(
+        isPresented: Binding<Bool>,
+        isEnableDismiss: Bool = true,
+        @ViewBuilder child: @escaping (@escaping VoidCallBack) -> SheetContent
+    ) -> some View {
+        modifier(
+            ActionBottomSheetModifier(
+                isPresented: isPresented,
+                isEnableDismiss: isEnableDismiss,
+                child: child
+            )
+        )
+    }
+}

--- a/DesignSystem/DesignSystem/Sources/Component/BottomSheet/ActionBottomSheet.swift
+++ b/DesignSystem/DesignSystem/Sources/Component/BottomSheet/ActionBottomSheet.swift
@@ -2,24 +2,46 @@
 //  ActionBottomSheet.swift
 //  DesignSystem
 //
-//  Created by Codex on 4/28/26.
+//  Created by 문종식 on 4/28/26.
 //
 
 import SwiftUI
 
-public struct ActionBottomSheetModifier<SheetView: View>: ViewModifier {
+public struct ActionBottomSheetItem<T> {
+    public let item: T
+    public let icon: BNImageAsset?
+    public let text: String
+    public let action: (T) -> Void
+
+    public init(
+        item: T,
+        icon: BNImageAsset? = nil,
+        text: String,
+        action: @escaping (T) -> Void
+    ) {
+        self.item = item
+        self.icon = icon
+        self.text = text
+        self.action = action
+    }
+}
+
+public struct ActionBottomSheetModifier<ActionType>: ViewModifier {
     @Binding private var isPresented: Bool
     private let isEnableDismiss: Bool
-    private let child: (@escaping VoidCallBack) -> SheetView
+    private let handleBottomSpacing: CGFloat
+    private let items: [ActionBottomSheetItem<ActionType>]
 
     public init(
         isPresented: Binding<Bool>,
         isEnableDismiss: Bool = true,
-        @ViewBuilder child: @escaping (@escaping VoidCallBack) -> SheetView
+        handleBottomSpacing: CGFloat = 26,
+        items: [ActionBottomSheetItem<ActionType>]
     ) {
         self._isPresented = isPresented
         self.isEnableDismiss = isEnableDismiss
-        self.child = child
+        self.handleBottomSpacing = handleBottomSpacing
+        self.items = items
     }
 
     public func body(content: Content) -> some View {
@@ -27,22 +49,53 @@ public struct ActionBottomSheetModifier<SheetView: View>: ViewModifier {
             .bnBottomSheet(
                 isPresented: $isPresented,
                 isEnableDismiss: isEnableDismiss,
-                child: child
+                handleBottomSpacing: handleBottomSpacing,
+                child: { dismiss in
+                    actionBottomSheetContent(dismiss: dismiss)
+                }
             )
+    }
+
+    @ViewBuilder
+    private func actionBottomSheetContent(dismiss: @escaping VoidCallBack) -> some View {
+        VStack(spacing: 18) {
+            ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                Button {
+                    dismiss()
+                    item.action(item.item)
+                } label: {
+                    HStack(spacing: 10) {
+                        if let icon = item.icon {
+                            BNImage(icon)
+                                .style(color: ColorPalette.gray900, size: 20)
+                        }
+                        BNText(item.text)
+                            .style(style: .s3sb, color: ColorPalette.gray900)
+                            .padding(.vertical, 6)
+                        Spacer()
+                    }
+                }
+            }
+        }
+        .padding(.top, 6)
+        .padding(.horizontal, 24)
+        .padding(.bottom, 30)
     }
 }
 
 public extension View {
-    func actionBottomSheet<SheetContent: View>(
+    func actionBottomSheet<ActionType>(
         isPresented: Binding<Bool>,
         isEnableDismiss: Bool = true,
-        @ViewBuilder child: @escaping (@escaping VoidCallBack) -> SheetContent
+        handleBottomSpacing: CGFloat = 26,
+        items: [ActionBottomSheetItem<ActionType>]
     ) -> some View {
         modifier(
             ActionBottomSheetModifier(
                 isPresented: isPresented,
                 isEnableDismiss: isEnableDismiss,
-                child: child
+                handleBottomSpacing: handleBottomSpacing,
+                items: items
             )
         )
     }

--- a/DesignSystem/DesignSystem/Sources/Component/BottomSheet/ActionBottomSheet.swift
+++ b/DesignSystem/DesignSystem/Sources/Component/BottomSheet/ActionBottomSheet.swift
@@ -29,18 +29,15 @@ public struct ActionBottomSheetItem<T> {
 public struct ActionBottomSheetModifier<ActionType>: ViewModifier {
     @Binding private var isPresented: Bool
     private let isEnableDismiss: Bool
-    private let handleBottomSpacing: CGFloat
     private let items: [ActionBottomSheetItem<ActionType>]
 
     public init(
         isPresented: Binding<Bool>,
         isEnableDismiss: Bool = true,
-        handleBottomSpacing: CGFloat = 26,
         items: [ActionBottomSheetItem<ActionType>]
     ) {
         self._isPresented = isPresented
         self.isEnableDismiss = isEnableDismiss
-        self.handleBottomSpacing = handleBottomSpacing
         self.items = items
     }
 
@@ -49,7 +46,6 @@ public struct ActionBottomSheetModifier<ActionType>: ViewModifier {
             .bnBottomSheet(
                 isPresented: $isPresented,
                 isEnableDismiss: isEnableDismiss,
-                handleBottomSpacing: handleBottomSpacing,
                 child: { dismiss in
                     actionBottomSheetContent(dismiss: dismiss)
                 }
@@ -87,14 +83,12 @@ public extension View {
     func actionBottomSheet<ActionType>(
         isPresented: Binding<Bool>,
         isEnableDismiss: Bool = true,
-        handleBottomSpacing: CGFloat = 26,
         items: [ActionBottomSheetItem<ActionType>]
     ) -> some View {
         modifier(
             ActionBottomSheetModifier(
                 isPresented: isPresented,
                 isEnableDismiss: isEnableDismiss,
-                handleBottomSpacing: handleBottomSpacing,
                 items: items
             )
         )

--- a/DesignSystem/DesignSystem/Sources/Component/BottomSheet/BNBottomSheet.swift
+++ b/DesignSystem/DesignSystem/Sources/Component/BottomSheet/BNBottomSheet.swift
@@ -12,16 +12,16 @@ public struct BNBottomSheetModifier<SheetView: View>: ViewModifier {
     @State private var dragOffset: CGFloat = 0
     @State private var isFullScreenViewVisible = false
     private let isEnableDismiss: Bool
-    private let sheetContent: (@escaping VoidCallBack) -> SheetView
+    private let sheetChild: (@escaping VoidCallBack) -> SheetView
     
     public init(
         isPresented: Binding<Bool>,
         isEnableDismiss: Bool,
-        @ViewBuilder content: @escaping (@escaping VoidCallBack) -> SheetView
+        @ViewBuilder child: @escaping (@escaping VoidCallBack) -> SheetView
     ) {
         self._isPresented = isPresented
         self.isEnableDismiss = isEnableDismiss
-        self.sheetContent = content
+        self.sheetChild = child
     }
     
     private let hiddenOffset: CGFloat = UIScreen.main.bounds.height
@@ -81,7 +81,7 @@ public struct BNBottomSheetModifier<SheetView: View>: ViewModifier {
             handleView
                 .padding(.top, 10)
                 .padding(.bottom, 16)
-            sheetContent(dismiss)
+            sheetChild(dismiss)
         }
         .frame(maxWidth: .infinity)
         .background(ColorPalette.gray0)
@@ -137,13 +137,13 @@ public extension View {
     func bnBottomSheet<SheetContent: View>(
         isPresented: Binding<Bool>,
         isEnableDismiss: Bool = true,
-        @ViewBuilder content: @escaping (@escaping VoidCallBack) -> SheetContent
+        @ViewBuilder child: @escaping (@escaping VoidCallBack) -> SheetContent
     ) -> some View {
         modifier(
             BNBottomSheetModifier(
                 isPresented: isPresented,
                 isEnableDismiss: isEnableDismiss,
-                content: content
+                child: child
             )
         )
     }

--- a/DesignSystem/DesignSystem/Sources/Component/BottomSheet/BNBottomSheet.swift
+++ b/DesignSystem/DesignSystem/Sources/Component/BottomSheet/BNBottomSheet.swift
@@ -12,15 +12,18 @@ public struct BNBottomSheetModifier<SheetView: View>: ViewModifier {
     @State private var dragOffset: CGFloat = 0
     @State private var isFullScreenViewVisible = false
     private let isEnableDismiss: Bool
+    private let handleBottomSpacing: CGFloat
     private let sheetChild: (@escaping VoidCallBack) -> SheetView
     
     public init(
         isPresented: Binding<Bool>,
         isEnableDismiss: Bool,
+        handleBottomSpacing: CGFloat = 26,
         @ViewBuilder child: @escaping (@escaping VoidCallBack) -> SheetView
     ) {
         self._isPresented = isPresented
         self.isEnableDismiss = isEnableDismiss
+        self.handleBottomSpacing = handleBottomSpacing
         self.sheetChild = child
     }
     
@@ -80,7 +83,7 @@ public struct BNBottomSheetModifier<SheetView: View>: ViewModifier {
         VStack(spacing: 0) {
             handleView
                 .padding(.top, 10)
-                .padding(.bottom, 16)
+                .padding(.bottom, handleBottomSpacing)
             sheetChild(dismiss)
         }
         .frame(maxWidth: .infinity)
@@ -92,14 +95,14 @@ public struct BNBottomSheetModifier<SheetView: View>: ViewModifier {
             )
         )
         .padding(.horizontal, 14)
-        .padding(.bottom, 10)
+        .padding(.bottom, 20)
         .animation(.linear(duration: 0.2), value: dragOffset)
     }
     
     @ViewBuilder
     private var handleView: some View {
         Capsule()
-            .fill(isEnableDismiss ? ColorPalette.fromHex("#D9D9D9"): ColorPalette.gray0)
+            .fill(isEnableDismiss ? ColorPalette.gray400: ColorPalette.gray0)
             .frame(width: 40, height: 4)
     }
     
@@ -137,12 +140,14 @@ public extension View {
     func bnBottomSheet<SheetContent: View>(
         isPresented: Binding<Bool>,
         isEnableDismiss: Bool = true,
+        handleBottomSpacing: CGFloat = 26,
         @ViewBuilder child: @escaping (@escaping VoidCallBack) -> SheetContent
     ) -> some View {
         modifier(
             BNBottomSheetModifier(
                 isPresented: isPresented,
                 isEnableDismiss: isEnableDismiss,
+                handleBottomSpacing: handleBottomSpacing,
                 child: child
             )
         )

--- a/DesignSystem/DesignSystem/Sources/Component/BottomSheet/BNBottomSheet.swift
+++ b/DesignSystem/DesignSystem/Sources/Component/BottomSheet/BNBottomSheet.swift
@@ -32,6 +32,7 @@ public struct BNBottomSheetModifier<SheetView: View>: ViewModifier {
         response: 0.3,
         dampingFraction: 1
     )
+    private let transitionDuration: TimeInterval = 0.3
     
     public func body(content: Content) -> some View {
         content
@@ -129,7 +130,7 @@ public struct BNBottomSheetModifier<SheetView: View>: ViewModifier {
     private func dismiss() {
         withAnimation(animation) {
             isFullScreenViewVisible = false
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + transitionDuration) {
                 isPresented = false
             }
         }

--- a/DesignSystem/DesignSystem/Sources/Component/BottomSheet/BottomSheetPreview.swift
+++ b/DesignSystem/DesignSystem/Sources/Component/BottomSheet/BottomSheetPreview.swift
@@ -2,7 +2,7 @@
 //  BottomSheetPreview.swift
 //  DesignSystem
 //
-//  Created by Codex on 4/28/26.
+//  Created by 문종식 on 4/28/26.
 //
 
 import SwiftUI
@@ -12,7 +12,12 @@ private struct BottomSheetPreviewContainer: View {
     @State private var showContent = false
     @State private var showOption = false
     @State private var showAction = false
-
+    private let actionItems: [ActionBottomSheetItem<String>] = [
+        .init(item: "camera", icon: .camera, text: "카메라로 직접 찍기") { _ in },
+        .init(item: "album", icon: .photo_album, text: "앨범에서 사진 선택") { _ in },
+        .init(item: "emtpy", text: "아이콘 없는 메뉴") { _ in }
+    ]
+    
     var body: some View {
         VStack(spacing: 12) {
             Button("Show Basic BottomSheet") { showBasic = true }
@@ -29,12 +34,10 @@ private struct BottomSheetPreviewContainer: View {
         .optionBottomSheet(isPresented: $showOption) { dismiss in
             previewChild(title: "OptionBottomSheet", dismiss: dismiss)
         }
-        .actionBottomSheet(isPresented: $showAction) { dismiss in
-            previewChild(title: "ActionBottomSheet", dismiss: dismiss)
-        }
+        .actionBottomSheet(isPresented: $showAction, items: actionItems)
         .padding()
     }
-
+    
     @ViewBuilder
     private func previewChild(title: String, dismiss: @escaping VoidCallBack) -> some View {
         VStack(spacing: 12) {

--- a/DesignSystem/DesignSystem/Sources/Component/BottomSheet/BottomSheetPreview.swift
+++ b/DesignSystem/DesignSystem/Sources/Component/BottomSheet/BottomSheetPreview.swift
@@ -7,16 +7,29 @@
 
 import SwiftUI
 
+private enum OptionPreviewItem: String, CaseIterable, OptionBottomSheetDisplayable {
+    case fashion = "패션"
+    case digital = "디지털"
+    case travel = "여행"
+    case food = "식품"
+    case hobby = "취미"
+    case sports = "스포츠"
+
+    var title: String { rawValue }
+}
+
 private struct BottomSheetPreviewContainer: View {
     @State private var showBasic = false
     @State private var showContent = false
     @State private var showOption = false
     @State private var showAction = false
+    @State private var selectedOptionItem: OptionPreviewItem? = .travel
     private let actionItems: [ActionBottomSheetItem<String>] = [
         .init(item: "camera", icon: .camera, text: "카메라로 직접 찍기") { _ in },
         .init(item: "album", icon: .photo_album, text: "앨범에서 사진 선택") { _ in },
         .init(item: "emtpy", text: "아이콘 없는 메뉴") { _ in }
     ]
+    private let optionItems: [OptionPreviewItem] = OptionPreviewItem.allCases
     
     var body: some View {
         VStack(spacing: 12) {
@@ -31,8 +44,13 @@ private struct BottomSheetPreviewContainer: View {
         .contentBottomSheet(isPresented: $showContent) { dismiss in
             previewChild(title: "ContentBottomSheet", dismiss: dismiss)
         }
-        .optionBottomSheet(isPresented: $showOption) { dismiss in
-            previewChild(title: "OptionBottomSheet", dismiss: dismiss)
+        .optionBottomSheet(
+            isPresented: $showOption,
+            title: "카테고리",
+            selectedItem: selectedOptionItem,
+            items: optionItems
+        ) { item in
+            selectedOptionItem = item
         }
         .actionBottomSheet(isPresented: $showAction, items: actionItems)
         .padding()

--- a/DesignSystem/DesignSystem/Sources/Component/BottomSheet/BottomSheetPreview.swift
+++ b/DesignSystem/DesignSystem/Sources/Component/BottomSheet/BottomSheetPreview.swift
@@ -20,7 +20,9 @@ private enum OptionPreviewItem: String, CaseIterable, OptionBottomSheetDisplayab
 
 private struct BottomSheetPreviewContainer: View {
     @State private var showBasic = false
-    @State private var showContent = false
+    @State private var showContentImageOnly = false
+    @State private var showContentTextOnly = false
+    @State private var showContentNone = false
     @State private var showOption = false
     @State private var showAction = false
     @State private var selectedOptionItem: OptionPreviewItem? = .travel
@@ -34,24 +36,62 @@ private struct BottomSheetPreviewContainer: View {
     var body: some View {
         VStack(spacing: 12) {
             Button("Show Basic BottomSheet") { showBasic = true }
-            Button("Show ContentBottomSheet") { showContent = true }
+            Button("Show ContentBottomSheet (Image)") { showContentImageOnly = true }
+            Button("Show ContentBottomSheet (Text)") { showContentTextOnly = true }
+            Button("Show ContentBottomSheet (None)") { showContentNone = true }
             Button("Show OptionBottomSheet") { showOption = true }
             Button("Show ActionBottomSheet") { showAction = true }
         }
         .bnBottomSheet(isPresented: $showBasic) { dismiss in
             previewChild(title: "Basic BottomSheet", dismiss: dismiss)
         }
-        .contentBottomSheet(isPresented: $showContent) { dismiss in
-            previewChild(title: "ContentBottomSheet", dismiss: dismiss)
-        }
+        .contentBottomSheet(
+            isPresented: $showContentImageOnly,
+            icon: .notification,
+            title: "알림 설정이 꺼져 있어요",
+            subTitle: "푸시 알림을 켜면 투표 결과를 놓치지 않아요.",
+            primaryButtonText: "설정 열기",
+            secondaryButtonText: "닫기",
+            didTapPrimaryButton: {},
+            didTapSecondaryButton: {},
+            customContent: {
+                BNImage(.notification_fill)
+                    .style(color: ColorPalette.gray950, size: 40)
+            }
+        )
+        .contentBottomSheet(
+            isPresented: $showContentTextOnly,
+            icon: .notification,
+            title: "알림 설정이 꺼져 있어요",
+            subTitle: "푸시 알림을 켜면 투표 결과를 놓치지 않아요.",
+            primaryButtonText: "설정 열기",
+            secondaryButtonText: "닫기",
+            didTapPrimaryButton: {},
+            didTapSecondaryButton: {},
+            customContent: {
+                BNText("아무 텍스트")
+                    .style(style: .b4m, color: ColorPalette.gray700)
+            }
+        )
+        .contentBottomSheet(
+            isPresented: $showContentNone,
+            icon: .notification,
+            title: "알림 설정이 꺼져 있어요",
+            subTitle: "푸시 알림을 켜면 투표 결과를 놓치지 않아요.",
+            primaryButtonText: "설정 열기",
+            secondaryButtonText: "닫기",
+            didTapPrimaryButton: {},
+            didTapSecondaryButton: {}
+        )
         .optionBottomSheet(
             isPresented: $showOption,
             title: "카테고리",
             selectedItem: selectedOptionItem,
-            items: optionItems
-        ) { item in
-            selectedOptionItem = item
-        }
+            items: optionItems,
+            didSelectItem: { item in
+                selectedOptionItem = item
+            }
+        )
         .actionBottomSheet(isPresented: $showAction, items: actionItems)
         .padding()
     }

--- a/DesignSystem/DesignSystem/Sources/Component/BottomSheet/BottomSheetPreview.swift
+++ b/DesignSystem/DesignSystem/Sources/Component/BottomSheet/BottomSheetPreview.swift
@@ -1,0 +1,53 @@
+//
+//  BottomSheetPreview.swift
+//  DesignSystem
+//
+//  Created by Codex on 4/28/26.
+//
+
+import SwiftUI
+
+private struct BottomSheetPreviewContainer: View {
+    @State private var showBasic = false
+    @State private var showContent = false
+    @State private var showOption = false
+    @State private var showAction = false
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Button("Show Basic BottomSheet") { showBasic = true }
+            Button("Show ContentBottomSheet") { showContent = true }
+            Button("Show OptionBottomSheet") { showOption = true }
+            Button("Show ActionBottomSheet") { showAction = true }
+        }
+        .bnBottomSheet(isPresented: $showBasic) { dismiss in
+            previewChild(title: "Basic BottomSheet", dismiss: dismiss)
+        }
+        .contentBottomSheet(isPresented: $showContent) { dismiss in
+            previewChild(title: "ContentBottomSheet", dismiss: dismiss)
+        }
+        .optionBottomSheet(isPresented: $showOption) { dismiss in
+            previewChild(title: "OptionBottomSheet", dismiss: dismiss)
+        }
+        .actionBottomSheet(isPresented: $showAction) { dismiss in
+            previewChild(title: "ActionBottomSheet", dismiss: dismiss)
+        }
+        .padding()
+    }
+
+    @ViewBuilder
+    private func previewChild(title: String, dismiss: @escaping VoidCallBack) -> some View {
+        VStack(spacing: 12) {
+            BNText(title)
+                .style(style: .s3sb, color: ColorPalette.gray800)
+            BNButton(text: "닫기", type: .capsule, state: .enabled, width: 120) {
+                dismiss()
+            }
+        }
+        .padding(.bottom, 20)
+    }
+}
+
+#Preview {
+    BottomSheetPreviewContainer()
+}

--- a/DesignSystem/DesignSystem/Sources/Component/BottomSheet/ContentBottomSheet.swift
+++ b/DesignSystem/DesignSystem/Sources/Component/BottomSheet/ContentBottomSheet.swift
@@ -7,48 +7,157 @@
 
 import SwiftUI
 
-public struct ContentBottomSheetModifier<SheetView: View>: ViewModifier {
+public struct ContentBottomSheetModifier: ViewModifier {
     @Binding private var isPresented: Bool
     private let isEnableDismiss: Bool
-    private let handleBottomSpacing: CGFloat
-    private let child: (@escaping VoidCallBack) -> SheetView
+    private let icon: BNImageAsset
+    private let title: String
+    private let subTitle: String
+    private let primaryButtonText: String
+    private let secondaryButtonText: String
+    private let didTapPrimaryButton: () -> Void
+    private let didTapSecondaryButton: () -> Void
+    private let customContent: AnyView?
 
     public init(
         isPresented: Binding<Bool>,
         isEnableDismiss: Bool = true,
-        handleBottomSpacing: CGFloat = 26,
-        @ViewBuilder child: @escaping (@escaping VoidCallBack) -> SheetView
+        icon: BNImageAsset,
+        title: String,
+        subTitle: String,
+        primaryButtonText: String,
+        secondaryButtonText: String,
+        didTapPrimaryButton: @escaping () -> Void,
+        didTapSecondaryButton: @escaping () -> Void,
+        customContent: AnyView? = nil
     ) {
         self._isPresented = isPresented
         self.isEnableDismiss = isEnableDismiss
-        self.handleBottomSpacing = handleBottomSpacing
-        self.child = child
+        self.icon = icon
+        self.title = title
+        self.subTitle = subTitle
+        self.primaryButtonText = primaryButtonText
+        self.secondaryButtonText = secondaryButtonText
+        self.didTapPrimaryButton = didTapPrimaryButton
+        self.didTapSecondaryButton = didTapSecondaryButton
+        self.customContent = customContent
     }
 
     public func body(content: Content) -> some View {
         content
             .bnBottomSheet(
                 isPresented: $isPresented,
-                isEnableDismiss: isEnableDismiss,
-                handleBottomSpacing: handleBottomSpacing,
-                child: child
-            )
+                isEnableDismiss: isEnableDismiss
+            ) { dismiss in
+                contentBottomSheetContent(dismiss: dismiss)
+            }
+    }
+
+    @ViewBuilder
+    private func contentBottomSheetContent(dismiss: @escaping VoidCallBack) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(ColorPalette.gray300)
+                    .frame(width: 50, height: 50)
+                    .overlay {
+                        BNImage(icon)
+                            .style(color: ColorPalette.gray950, size: 30)
+                    }
+                Spacer()
+            }
+            .padding(.horizontal, 6)
+
+            VStack(alignment: .leading, spacing: 26) {
+                VStack(alignment: .leading, spacing: 10) {
+                    BNText(title)
+                        .style(style: .s1sb, color: ColorPalette.gray950)
+                    BNText(subTitle)
+                        .style(style: .b4m, color: ColorPalette.gray700)
+                }
+                .padding(.horizontal, 6)
+
+                if let customContent {
+                    customContent
+                        .padding(.horizontal, 6)
+                }
+
+                HStack(spacing: 10) {
+                    BNButton(
+                        text: primaryButtonText,
+                        type: .primary,
+                        state: .enabled
+                    ) {
+                        dismiss()
+                        didTapPrimaryButton()
+                    }
+                    BNButton(
+                        text: secondaryButtonText,
+                        type: .secondaryLarge,
+                        state: .enabled
+                    ) {
+                        dismiss()
+                        didTapSecondaryButton()
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 18)
+        .padding(.bottom, 16)
     }
 }
 
 public extension View {
-    func contentBottomSheet<SheetContent: View>(
+    func contentBottomSheet(
         isPresented: Binding<Bool>,
         isEnableDismiss: Bool = true,
-        handleBottomSpacing: CGFloat = 26,
-        @ViewBuilder child: @escaping (@escaping VoidCallBack) -> SheetContent
+        icon: BNImageAsset,
+        title: String,
+        subTitle: String,
+        primaryButtonText: String,
+        secondaryButtonText: String,
+        didTapPrimaryButton: @escaping () -> Void,
+        didTapSecondaryButton: @escaping () -> Void
     ) -> some View {
         modifier(
             ContentBottomSheetModifier(
                 isPresented: isPresented,
                 isEnableDismiss: isEnableDismiss,
-                handleBottomSpacing: handleBottomSpacing,
-                child: child
+                icon: icon,
+                title: title,
+                subTitle: subTitle,
+                primaryButtonText: primaryButtonText,
+                secondaryButtonText: secondaryButtonText,
+                didTapPrimaryButton: didTapPrimaryButton,
+                didTapSecondaryButton: didTapSecondaryButton
+            )
+        )
+    }
+
+    func contentBottomSheet<CustomContent: View>(
+        isPresented: Binding<Bool>,
+        isEnableDismiss: Bool = true,
+        icon: BNImageAsset,
+        title: String,
+        subTitle: String,
+        primaryButtonText: String,
+        secondaryButtonText: String,
+        didTapPrimaryButton: @escaping () -> Void,
+        didTapSecondaryButton: @escaping () -> Void,
+        @ViewBuilder customContent: @escaping () -> CustomContent
+    ) -> some View {
+        modifier(
+            ContentBottomSheetModifier(
+                isPresented: isPresented,
+                isEnableDismiss: isEnableDismiss,
+                icon: icon,
+                title: title,
+                subTitle: subTitle,
+                primaryButtonText: primaryButtonText,
+                secondaryButtonText: secondaryButtonText,
+                didTapPrimaryButton: didTapPrimaryButton,
+                didTapSecondaryButton: didTapSecondaryButton,
+                customContent: AnyView(customContent())
             )
         )
     }

--- a/DesignSystem/DesignSystem/Sources/Component/BottomSheet/ContentBottomSheet.swift
+++ b/DesignSystem/DesignSystem/Sources/Component/BottomSheet/ContentBottomSheet.swift
@@ -85,7 +85,7 @@ public struct ContentBottomSheetModifier: ViewModifier {
                 HStack(spacing: 10) {
                     BNButton(
                         text: primaryButtonText,
-                        type: .primary,
+                        type: .secondaryLarge,
                         state: .enabled
                     ) {
                         dismiss()
@@ -93,7 +93,7 @@ public struct ContentBottomSheetModifier: ViewModifier {
                     }
                     BNButton(
                         text: secondaryButtonText,
-                        type: .secondaryLarge,
+                        type: .primary,
                         state: .enabled
                     ) {
                         dismiss()

--- a/DesignSystem/DesignSystem/Sources/Component/BottomSheet/ContentBottomSheet.swift
+++ b/DesignSystem/DesignSystem/Sources/Component/BottomSheet/ContentBottomSheet.swift
@@ -1,0 +1,49 @@
+//
+//  ContentBottomSheet.swift
+//  DesignSystem
+//
+//  Created by Codex on 4/28/26.
+//
+
+import SwiftUI
+
+public struct ContentBottomSheetModifier<SheetView: View>: ViewModifier {
+    @Binding private var isPresented: Bool
+    private let isEnableDismiss: Bool
+    private let child: (@escaping VoidCallBack) -> SheetView
+
+    public init(
+        isPresented: Binding<Bool>,
+        isEnableDismiss: Bool = true,
+        @ViewBuilder child: @escaping (@escaping VoidCallBack) -> SheetView
+    ) {
+        self._isPresented = isPresented
+        self.isEnableDismiss = isEnableDismiss
+        self.child = child
+    }
+
+    public func body(content: Content) -> some View {
+        content
+            .bnBottomSheet(
+                isPresented: $isPresented,
+                isEnableDismiss: isEnableDismiss,
+                child: child
+            )
+    }
+}
+
+public extension View {
+    func contentBottomSheet<SheetContent: View>(
+        isPresented: Binding<Bool>,
+        isEnableDismiss: Bool = true,
+        @ViewBuilder child: @escaping (@escaping VoidCallBack) -> SheetContent
+    ) -> some View {
+        modifier(
+            ContentBottomSheetModifier(
+                isPresented: isPresented,
+                isEnableDismiss: isEnableDismiss,
+                child: child
+            )
+        )
+    }
+}

--- a/DesignSystem/DesignSystem/Sources/Component/BottomSheet/ContentBottomSheet.swift
+++ b/DesignSystem/DesignSystem/Sources/Component/BottomSheet/ContentBottomSheet.swift
@@ -2,7 +2,7 @@
 //  ContentBottomSheet.swift
 //  DesignSystem
 //
-//  Created by Codex on 4/28/26.
+//  Created by 문종식 on 4/28/26.
 //
 
 import SwiftUI
@@ -10,15 +10,18 @@ import SwiftUI
 public struct ContentBottomSheetModifier<SheetView: View>: ViewModifier {
     @Binding private var isPresented: Bool
     private let isEnableDismiss: Bool
+    private let handleBottomSpacing: CGFloat
     private let child: (@escaping VoidCallBack) -> SheetView
 
     public init(
         isPresented: Binding<Bool>,
         isEnableDismiss: Bool = true,
+        handleBottomSpacing: CGFloat = 26,
         @ViewBuilder child: @escaping (@escaping VoidCallBack) -> SheetView
     ) {
         self._isPresented = isPresented
         self.isEnableDismiss = isEnableDismiss
+        self.handleBottomSpacing = handleBottomSpacing
         self.child = child
     }
 
@@ -27,6 +30,7 @@ public struct ContentBottomSheetModifier<SheetView: View>: ViewModifier {
             .bnBottomSheet(
                 isPresented: $isPresented,
                 isEnableDismiss: isEnableDismiss,
+                handleBottomSpacing: handleBottomSpacing,
                 child: child
             )
     }
@@ -36,12 +40,14 @@ public extension View {
     func contentBottomSheet<SheetContent: View>(
         isPresented: Binding<Bool>,
         isEnableDismiss: Bool = true,
+        handleBottomSpacing: CGFloat = 26,
         @ViewBuilder child: @escaping (@escaping VoidCallBack) -> SheetContent
     ) -> some View {
         modifier(
             ContentBottomSheetModifier(
                 isPresented: isPresented,
                 isEnableDismiss: isEnableDismiss,
+                handleBottomSpacing: handleBottomSpacing,
                 child: child
             )
         )

--- a/DesignSystem/DesignSystem/Sources/Component/BottomSheet/OptionBottomSheet.swift
+++ b/DesignSystem/DesignSystem/Sources/Component/BottomSheet/OptionBottomSheet.swift
@@ -7,22 +7,32 @@
 
 import SwiftUI
 
-public struct OptionBottomSheetModifier<SheetView: View>: ViewModifier {
+public protocol OptionBottomSheetDisplayable {
+    var title: String { get }
+}
+
+public struct OptionBottomSheetModifier<Item: OptionBottomSheetDisplayable>: ViewModifier {
     @Binding private var isPresented: Bool
     private let isEnableDismiss: Bool
-    private let handleBottomSpacing: CGFloat
-    private let child: (@escaping VoidCallBack) -> SheetView
+    private let title: String
+    private let selectedItem: Item?
+    private let items: [Item]
+    private let didSelectItem: (Item) -> Void
 
     public init(
         isPresented: Binding<Bool>,
         isEnableDismiss: Bool = true,
-        handleBottomSpacing: CGFloat = 26,
-        @ViewBuilder child: @escaping (@escaping VoidCallBack) -> SheetView
+        title: String,
+        selectedItem: Item?,
+        items: [Item],
+        didSelectItem: @escaping (Item) -> Void = { _ in }
     ) {
         self._isPresented = isPresented
         self.isEnableDismiss = isEnableDismiss
-        self.handleBottomSpacing = handleBottomSpacing
-        self.child = child
+        self.title = title
+        self.selectedItem = selectedItem
+        self.items = items
+        self.didSelectItem = didSelectItem
     }
 
     public func body(content: Content) -> some View {
@@ -30,25 +40,104 @@ public struct OptionBottomSheetModifier<SheetView: View>: ViewModifier {
             .bnBottomSheet(
                 isPresented: $isPresented,
                 isEnableDismiss: isEnableDismiss,
-                handleBottomSpacing: handleBottomSpacing,
-                child: child
+                handleBottomSpacing: 16,
+                child: { dismiss in
+                    optionBottomSheetContent(dismiss: dismiss)
+                }
             )
+    }
+
+    @ViewBuilder
+    private func optionBottomSheetContent(dismiss: @escaping VoidCallBack) -> some View {
+        VStack(alignment: .leading, spacing: 20) {
+            BNText(title)
+                .style(style: .s1sb, color: ColorPalette.gray950)
+
+            ZStack {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(spacing: 18) {
+                            ForEach(Array(items.enumerated()), id: \.offset) { index, item in
+                                Button {
+                                    dismiss()
+                                    didSelectItem(item)
+                                } label: {
+                                    HStack {
+                                        BNText(item.title)
+                                            .style(
+                                                style: isSelected(item) ? .s3sb : .b3m,
+                                                color: isSelected(item) ? ColorPalette.gray950 : ColorPalette.gray700
+                                            )
+                                        Spacer()
+                                        BNImage(.check)
+                                            .style(color: ColorPalette.gray950, size: 20)
+                                            .opacity(isSelected(item) ? 1 : 0)
+                                            .padding(.vertical, 5)
+                                    }
+                                }
+                                .id(index)
+                            }
+                            Spacer(minLength: 70)
+                        }
+                    }
+                    .scrollIndicators(.hidden)
+                    .defaultScrollAnchor(.top)
+                    .onAppear {
+                        scrollToSelectedItemIfNeeded(with: proxy)
+                    }
+                    .onChange(of: selectedItem?.title) { _, _ in
+                        scrollToSelectedItemIfNeeded(with: proxy)
+                    }
+                }
+
+                VStack {
+                    Spacer()
+                    LinearGradient(
+                        gradient: Gradient(colors: [
+                            ColorPalette.gray0.opacity(0),
+                            ColorPalette.gray0
+                        ]),
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                    .frame(height: 70)
+                }
+            }
+            .frame(height: 238)
+        }
+        .padding(.horizontal, 24)
+    }
+
+    private func isSelected(_ item: Item) -> Bool {
+        selectedItem?.title == item.title
+    }
+
+    private func scrollToSelectedItemIfNeeded(with proxy: ScrollViewProxy) {
+        guard let selectedTitle = selectedItem?.title else { return }
+        guard let selectedIndex = items.firstIndex(where: { $0.title == selectedTitle }) else { return }
+        DispatchQueue.main.async {
+            proxy.scrollTo(selectedIndex, anchor: .center)
+        }
     }
 }
 
 public extension View {
-    func optionBottomSheet<SheetContent: View>(
+    func optionBottomSheet<Item: OptionBottomSheetDisplayable>(
         isPresented: Binding<Bool>,
         isEnableDismiss: Bool = true,
-        handleBottomSpacing: CGFloat = 26,
-        @ViewBuilder child: @escaping (@escaping VoidCallBack) -> SheetContent
+        title: String,
+        selectedItem: Item?,
+        items: [Item],
+        didSelectItem: @escaping (Item) -> Void = { _ in }
     ) -> some View {
         modifier(
             OptionBottomSheetModifier(
                 isPresented: isPresented,
                 isEnableDismiss: isEnableDismiss,
-                handleBottomSpacing: handleBottomSpacing,
-                child: child
+                title: title,
+                selectedItem: selectedItem,
+                items: items,
+                didSelectItem: didSelectItem
             )
         )
     }

--- a/DesignSystem/DesignSystem/Sources/Component/BottomSheet/OptionBottomSheet.swift
+++ b/DesignSystem/DesignSystem/Sources/Component/BottomSheet/OptionBottomSheet.swift
@@ -2,7 +2,7 @@
 //  OptionBottomSheet.swift
 //  DesignSystem
 //
-//  Created by Codex on 4/28/26.
+//  Created by 문종식 on 4/28/26.
 //
 
 import SwiftUI
@@ -10,15 +10,18 @@ import SwiftUI
 public struct OptionBottomSheetModifier<SheetView: View>: ViewModifier {
     @Binding private var isPresented: Bool
     private let isEnableDismiss: Bool
+    private let handleBottomSpacing: CGFloat
     private let child: (@escaping VoidCallBack) -> SheetView
 
     public init(
         isPresented: Binding<Bool>,
         isEnableDismiss: Bool = true,
+        handleBottomSpacing: CGFloat = 26,
         @ViewBuilder child: @escaping (@escaping VoidCallBack) -> SheetView
     ) {
         self._isPresented = isPresented
         self.isEnableDismiss = isEnableDismiss
+        self.handleBottomSpacing = handleBottomSpacing
         self.child = child
     }
 
@@ -27,6 +30,7 @@ public struct OptionBottomSheetModifier<SheetView: View>: ViewModifier {
             .bnBottomSheet(
                 isPresented: $isPresented,
                 isEnableDismiss: isEnableDismiss,
+                handleBottomSpacing: handleBottomSpacing,
                 child: child
             )
     }
@@ -36,12 +40,14 @@ public extension View {
     func optionBottomSheet<SheetContent: View>(
         isPresented: Binding<Bool>,
         isEnableDismiss: Bool = true,
+        handleBottomSpacing: CGFloat = 26,
         @ViewBuilder child: @escaping (@escaping VoidCallBack) -> SheetContent
     ) -> some View {
         modifier(
             OptionBottomSheetModifier(
                 isPresented: isPresented,
                 isEnableDismiss: isEnableDismiss,
+                handleBottomSpacing: handleBottomSpacing,
                 child: child
             )
         )

--- a/DesignSystem/DesignSystem/Sources/Component/BottomSheet/OptionBottomSheet.swift
+++ b/DesignSystem/DesignSystem/Sources/Component/BottomSheet/OptionBottomSheet.swift
@@ -1,0 +1,49 @@
+//
+//  OptionBottomSheet.swift
+//  DesignSystem
+//
+//  Created by Codex on 4/28/26.
+//
+
+import SwiftUI
+
+public struct OptionBottomSheetModifier<SheetView: View>: ViewModifier {
+    @Binding private var isPresented: Bool
+    private let isEnableDismiss: Bool
+    private let child: (@escaping VoidCallBack) -> SheetView
+
+    public init(
+        isPresented: Binding<Bool>,
+        isEnableDismiss: Bool = true,
+        @ViewBuilder child: @escaping (@escaping VoidCallBack) -> SheetView
+    ) {
+        self._isPresented = isPresented
+        self.isEnableDismiss = isEnableDismiss
+        self.child = child
+    }
+
+    public func body(content: Content) -> some View {
+        content
+            .bnBottomSheet(
+                isPresented: $isPresented,
+                isEnableDismiss: isEnableDismiss,
+                child: child
+            )
+    }
+}
+
+public extension View {
+    func optionBottomSheet<SheetContent: View>(
+        isPresented: Binding<Bool>,
+        isEnableDismiss: Bool = true,
+        @ViewBuilder child: @escaping (@escaping VoidCallBack) -> SheetContent
+    ) -> some View {
+        modifier(
+            OptionBottomSheetModifier(
+                isPresented: isPresented,
+                isEnableDismiss: isEnableDismiss,
+                child: child
+            )
+        )
+    }
+}

--- a/Feature/Vote/Vote/Sources/Extension/FeedCategory+OptionBottomSheetDisplayable.swift
+++ b/Feature/Vote/Vote/Sources/Extension/FeedCategory+OptionBottomSheetDisplayable.swift
@@ -1,0 +1,13 @@
+//
+//  FeedCategory+OptionBottomSheetDisplayable.swift
+//  Vote
+//
+//  Created by 문종식 on 4/28/26.
+//
+
+import DesignSystem
+import Domain
+
+extension FeedCategory: OptionBottomSheetDisplayable {
+    public var title: String { displayName }
+}

--- a/Feature/Vote/Vote/Sources/Models/PostVote/PhotoSourceAction.swift
+++ b/Feature/Vote/Vote/Sources/Models/PostVote/PhotoSourceAction.swift
@@ -1,0 +1,11 @@
+//
+//  PhotoSourceAction.swift
+//  Vote
+//
+//  Created by 문종식 on 4/28/26.
+//
+
+enum PhotoSourceAction {
+    case camera
+    case album
+}

--- a/Feature/Vote/Vote/Sources/ViewModels/PostVote/CreateVoteViewModel.swift
+++ b/Feature/Vote/Vote/Sources/ViewModels/PostVote/CreateVoteViewModel.swift
@@ -150,6 +150,21 @@ public final class CreateVoteViewModel: ObservableObject {
         showPhotoSourceBottomSheet = true
     }
 
+    var photoSourceActionItems: [ActionBottomSheetItem<PhotoSourceAction>] {
+        [
+            .init(item: .camera, icon: .camera, text: "카메라로 직접 찍기") { [weak self] _ in
+                Task {
+                    await self?.checkCameraPermission()
+                }
+            },
+            .init(item: .album, icon: .photo_album, text: "앨범에서 사진 선택") { [weak self] _ in
+                Task {
+                    await self?.checkAlbumPermission()
+                }
+            }
+        ]
+    }
+
     @MainActor
     func checkPhotoPermission() async {
         await checkAlbumPermission()

--- a/Feature/Vote/Vote/Sources/Views/PostVote/CreateVoteView.swift
+++ b/Feature/Vote/Vote/Sources/Views/PostVote/CreateVoteView.swift
@@ -126,44 +126,20 @@ public struct CreateVoteView: View {
             )
             .ignoresSafeArea()
         }
-        .bnBottomSheet(
+        .optionBottomSheet(
             isPresented: $viewModel.showCategoryBottomSheet,
-            isEnableDismiss: true,
-        ) { dismiss in
-            CategorySheetView(
-                viewModel.categories,
-                viewModel.category
-            ) { category in
-                dismiss()
-                viewModel.didChangeCategory(category)
-            }
+            title: "카테고리",
+            selectedItem: viewModel.category,
+            items: viewModel.categories
+        ) { category in
+            viewModel.didChangeCategory(category)
         }
-        .bnBottomSheet(
+        .actionBottomSheet(
             isPresented: $viewModel.showPhotoSourceBottomSheet,
-            isEnableDismiss: true
-        ) { dismiss in
-            PhotoSourceSheetView(
-                didTapCamera: {
-                    dismiss()
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
-                        Task {
-                            await viewModel.checkCameraPermission()
-                        }
-                    }
-                },
-                didTapAlbum: {
-                    dismiss()
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
-                        Task {
-                            await viewModel.checkAlbumPermission()
-                        }
-                    }
-                }
-            )
-        }
+            items: viewModel.photoSourceActionItems
+        )
         .bnAlert(
             isPresented: $viewModel.showCustomAlert,
-            isEnableDismiss: true,
             config: BNAlertConfig(
                 title: viewModel.photoPermissionAlertTitle,
                 message: viewModel.photoPermissionAlertMessage,
@@ -180,7 +156,6 @@ public struct CreateVoteView: View {
         )
         .bnAlert(
             isPresented: $viewModel.showCancelAlert,
-            isEnableDismiss: true,
             config: BNAlertConfig(
                 title: "다음에 등록할까요?",
                 message: "지금까지 쓴 내용은 저장되지 않아요.",
@@ -201,7 +176,6 @@ public struct CreateVoteView: View {
         )
         .bnAlert(
             isPresented: $viewModel.showRestorePendingAlert,
-            isEnableDismiss: true,
             config: BNAlertConfig(
                 title: "이전에 작성하던 글이 있어요!",
                 message: "[닫기] 선택 시 해당 내용은 복구할 수 없어요.",
@@ -405,7 +379,7 @@ public struct CreateVoteView: View {
                 }
             }
             .disabled(viewModel.isPhotoPickerEnabled == false)
-
+            
             ForEach(Array(viewModel.selectedPhotos.enumerated()), id: \.offset) { index, photo in
                 photo.image
                     .resizable()

--- a/Service/Service/Sources/Network/APIConstants.swift
+++ b/Service/Service/Sources/Network/APIConstants.swift
@@ -21,7 +21,7 @@ public enum APIConstants {
         }
     }
     private static var buildScheme: BuildScheme {
-        .release
+        .debug
     }
     
     public static var baseURL: String? {

--- a/Service/Service/Sources/Network/APIConstants.swift
+++ b/Service/Service/Sources/Network/APIConstants.swift
@@ -21,7 +21,7 @@ public enum APIConstants {
         }
     }
     private static var buildScheme: BuildScheme {
-        .debug
+        .release
     }
     
     public static var baseURL: String? {


### PR DESCRIPTION
<!-- pull_request_template.md -->

## 📌 Summary
<!-- PR 요약을 써주세요. -->

- 기존 바텀시트를 Bottom Sheet, Options Sheet, Actions Sheet 세분화
- 기본 바텀시트도 그대로 사용할 수 있도록 유지
- `BottomSheetPreviewContainer`를 통해 각 바텀시트의 동작을 확인할 수 있도록 했습니다.

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->

- closed #107 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->

## 📚 Reference
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->

## 🔥 Test
<!-- Test -->

`BottomSheetPreviewContainer`를 통해 확인 할 수 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 새로운 하단 시트 컴포넌트로 더욱 다양한 사용자 상호작용 옵션 추가
  * 카테고리 선택 및 작업 선택을 위한 개선된 UI 제공
  * 사진 소스 선택 기능 강화

* **개선 사항**
  * 하단 시트 간격 및 스타일 최적화
  * 색상 팔레트 업데이트로 시각적 일관성 개선
  * 하단 시트 해제 애니메이션 개선

* **Chores**
  * 앱 버전 업데이트 (0.0.6 → 0.0.7)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->